### PR TITLE
Improve mobile responsiveness across components

### DIFF
--- a/src/_includes/components/about-me.ejs
+++ b/src/_includes/components/about-me.ejs
@@ -16,7 +16,7 @@
         </div>
       </div>
       <div class="about-me__image">
-        <img src="/assets/images/profile.jpg" alt="Profile photo of Stijn" class="profile-image">
+        <img src="/assets/images/profile.jpg" alt="Profile photo of Stijn" class="profile-image" loading="lazy">
       </div>
     </div>
   </div>

--- a/src/_includes/components/background_loop.ejs
+++ b/src/_includes/components/background_loop.ejs
@@ -8,10 +8,11 @@
         </video>
       <% } else { %>
         <!-- Default to image -->
-        <img 
-          class="background-media <%= index === 0 ? 'active' : '' %>" 
-          src="<%= item.src %>" 
+        <img
+          class="background-media <%= index === 0 ? 'active' : '' %>"
+          src="<%= item.src %>"
           alt="<%= item.alt || 'Background image' %>"
+          loading="lazy"
         />
       <% } %>
     <% }); %>

--- a/src/_includes/components/card.ejs
+++ b/src/_includes/components/card.ejs
@@ -2,7 +2,7 @@
 <div class="content-card <%= locals.className ? className : '' %>">
   <% if (locals.image) { %>
   <div class="content-card-image">
-    <img src="<%= image %>" alt="<%= title || 'Card image' %>" />
+    <img src="<%= image %>" alt="<%= title || 'Card image' %>" loading="lazy" />
   </div>
   <% } %>
   

--- a/src/_includes/components/frontpage-hero.ejs
+++ b/src/_includes/components/frontpage-hero.ejs
@@ -2,7 +2,7 @@
   <!-- Logo positioned at left edge of screen -->
   <div class="logo-bar">
     <a href="/" aria-label="Home">
-      <img src="/assets/images/logo_white.png" alt="Stijn Stevens Logo">
+      <img src="/assets/images/logo_white.png" alt="Stijn Stevens Logo" loading="lazy">
     </a>
   </div>
   

--- a/src/_includes/components/hover_infobox.ejs
+++ b/src/_includes/components/hover_infobox.ejs
@@ -13,7 +13,7 @@
       <!-- Add fixed container to maintain aspect ratio -->
       <div class="infobox-image-container">
         <!-- Always include an image element for JavaScript to reference -->
-        <img src="<%= locals.image || '' %>" alt="<%= locals.title || 'Project image' %>" />
+        <img src="<%= locals.image || '' %>" alt="<%= locals.title || 'Project image' %>" loading="lazy" />
       </div>
     </div>
     <% } %>
@@ -30,7 +30,7 @@
             <i class="<%= locals.iconClass %>"></i>
           <% } else if (locals.iconType === 'svg-file' && locals.svgPath) { %>
             <!-- SVG file reference -->
-            <img src="<%= locals.svgPath %>" alt="Icon" class="svg-icon" />
+            <img src="<%= locals.svgPath %>" alt="Icon" class="svg-icon" loading="lazy" />
           <% } else if (locals.iconType === 'custom-svg' && locals.svgContent) { %>
             <!-- Inline custom SVG -->
             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">

--- a/src/_includes/components/lightbox.ejs
+++ b/src/_includes/components/lightbox.ejs
@@ -206,4 +206,21 @@
     flex: 2;
   }
 }
+
+@media (max-width: 576px) {
+  .lightbox-content {
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .lightbox-close {
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 36px;
+    height: 36px;
+  }
+}
 </style> 

--- a/src/_includes/components/navigation.ejs
+++ b/src/_includes/components/navigation.ejs
@@ -2,7 +2,7 @@
   <!-- Logo positioned at left edge of screen -->
   <div class="logo-bar">
     <a href="/" aria-label="Home">
-      <img src="/assets/images/logo_white.png" alt="Stijn Stevens Logo">
+      <img src="/assets/images/logo_white.png" alt="Stijn Stevens Logo" loading="lazy">
     </a>
   </div>
   

--- a/src/_includes/components/post-card.ejs
+++ b/src/_includes/components/post-card.ejs
@@ -2,7 +2,7 @@
 <div class="post-card">
   <% if (post.data.cover) { %>
     <div class="post-card-image">
-      <img src="<%= post.data.cover %>" alt="<%= post.data.title %>">
+      <img src="<%= post.data.cover %>" alt="<%= post.data.title %>" loading="lazy">
     </div>
   <% } else { %>
     <div class="post-card-image" style="background-color: var(--secondary-color); display: flex; align-items: center; justify-content: center;">

--- a/src/_includes/components/video-embed.ejs
+++ b/src/_includes/components/video-embed.ejs
@@ -17,11 +17,12 @@ if (provider === 'youtube') {
 <% if (embedUrl) { %>
 <div class="<%= embedClass %>">
   <div class="rich-content-video-wrapper">
-    <iframe 
-      src="<%= embedUrl %>" 
+    <iframe
+      src="<%= embedUrl %>"
       title="<%= title || 'Video' %>"
-      frameborder="0" 
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      loading="lazy"
       allowfullscreen>
     </iframe>
   </div>

--- a/src/assets/styles/animations.css
+++ b/src/assets/styles/animations.css
@@ -35,6 +35,12 @@
   transform: translateX(-50px);
 }
 
+@media (max-width: 576px) {
+  [data-scroll-animation="fade-up"] {
+    transform: translateY(20px);
+  }
+}
+
 /* Staggered animation for letter-by-letter effects */
 .animated-title {
   overflow: hidden;

--- a/src/assets/styles/background-loop.css
+++ b/src/assets/styles/background-loop.css
@@ -8,6 +8,18 @@
   overflow: hidden;
 }
 
+@media (max-width: 768px) {
+  .background-loop {
+    height: 30vh;
+  }
+}
+
+@media (max-width: 576px) {
+  .background-loop {
+    height: 25vh;
+  }
+}
+
 .background-media {
   position: absolute;
   top: 0;

--- a/src/assets/styles/breadcrumb.css
+++ b/src/assets/styles/breadcrumb.css
@@ -33,3 +33,15 @@
   margin: 0 0.5rem;
   color: rgba(255, 255, 255, 0.8);
 }
+
+@media (max-width: 576px) {
+  .breadcrumb {
+    font-size: 0.8rem;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .breadcrumb-separator {
+    display: none;
+  }
+}

--- a/src/assets/styles/button.css
+++ b/src/assets/styles/button.css
@@ -149,3 +149,11 @@
 .border-button::after {
     display: none;
 }
+
+@media (max-width: 576px) {
+    .btn,
+    .border-button {
+        padding: 0.5rem 1rem;
+        font-size: 0.85rem;
+    }
+}

--- a/src/assets/styles/footer.css
+++ b/src/assets/styles/footer.css
@@ -130,3 +130,22 @@
         margin-top: 2rem;
     }
 }
+
+@media (max-width: 576px) {
+    .footer {
+        padding: 3rem 0 1.5rem;
+        margin-top: 3rem;
+    }
+
+    .footer-email a {
+        font-size: 1.5rem;
+    }
+
+    .footer-quote {
+        font-size: 0.9rem;
+    }
+
+    .footer-bottom {
+        margin-top: 3rem;
+    }
+}

--- a/src/assets/styles/hover-infobox.css
+++ b/src/assets/styles/hover-infobox.css
@@ -448,3 +448,9 @@
 .hover-infobox[data-max-width="large"] .infobox-content {
   width: 80% !important;
 }
+
+@media (max-width: 768px) {
+  .hover-infobox {
+    display: none;
+  }
+}

--- a/src/assets/styles/post-card.css
+++ b/src/assets/styles/post-card.css
@@ -80,3 +80,22 @@
     text-decoration: none;
     color: var(--text-color);
 }
+@media (max-width: 768px) {
+  .post-card {
+    margin-bottom: 1.5rem;
+  }
+  .post-card-image {
+    height: 160px;
+  }
+  .post-card-content {
+    padding: 1rem;
+  }
+  .post-card-title {
+    font-size: 1.25rem;
+  }
+}
+@media (max-width: 576px) {
+  .post-card-title {
+    font-size: 1.1rem;
+  }
+}

--- a/src/assets/styles/rich-content.css
+++ b/src/assets/styles/rich-content.css
@@ -246,3 +246,20 @@
     padding-right: 10rem;
   }
 }
+@media (max-width: 768px) {
+  .rich-content-block {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .rich-content-video-wrapper {
+    margin: var(--spacing-md) auto;
+  }
+}
+@media (max-width: 576px) {
+  .rich-content-block {
+    margin-bottom: var(--spacing-md);
+  }
+  .rich-content-video-wrapper {
+    margin: var(--spacing-sm) auto;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak post-card spacing and sizing for mobile
- hide hover infobox on small screens
- refine rich-content spacing for small devices
- add lazy loading to video embed iframe and extra lightbox/mobile footer rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400d52ceec8331b4f7be2f03704982