### PR TITLE
Add Docker compose deployment with webhook automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Strapi secrets
+APP_KEYS=your_app_keys
+API_TOKEN_SALT=your_api_token_salt
+ADMIN_JWT_SECRET=your_admin_jwt_secret
+JWT_SECRET=your_jwt_secret
+TRANSFER_TOKEN_SALT=your_transfer_token_salt
+
+# Webhook secrets
+GITHUB_SECRET=your_github_webhook_secret
+STRAPI_WEBHOOK_SECRET=your_strapi_webhook_secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,99 @@
+# Deployment Guide
+
+This project is split into two parts:
+- **portfolio-cms** – a Strapi CMS.
+- **portfolio-frontend** – an Eleventy static site that pulls data from Strapi.
+
+The provided Docker Compose setup builds and runs both applications along with a
+small webhook server. The webhook server listens for GitHub pushes and Strapi
+content changes so the static site stays up to date.
+
+## 1. Prerequisites
+
+* A machine with Docker and Docker Compose installed (your Mac mini).
+* Ports 22, 80 and 443 forwarded to that machine.
+* A domain name pointing to your home IP (optional but recommended).
+
+## 2. Preparing the Repository
+
+Clone the repository on the server:
+
+```bash
+git clone <your fork or repo url>
+cd portfolio-website
+```
+
+Copy the example environment file and edit the values to strong secrets:
+
+```bash
+cp .env.example .env
+nano .env
+```
+
+The **APP_KEYS** and other Strapi variables must be filled in. The webhook
+secrets can be any random strings; you will use them when configuring GitHub and
+Strapi.
+
+## 3. Building and Running with Docker
+
+From the project root run:
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+This will build the Strapi, frontend and webhook images, then start the
+containers. The first start may take a while because the frontend waits for
+Strapi and then generates the static files.
+
+Once the containers are running you should be able to visit:
+
+* `http://<server-ip>/` – your static site.
+* `http://<server-ip>/admin/` – the Strapi admin panel.
+
+## 4. Configuring Webhooks
+
+### GitHub
+
+1. Go to the repository settings on GitHub and open **Webhooks**.
+2. Add a webhook with:
+   * **Payload URL**: `http://<your-domain>/webhook/github`
+   * **Content type**: `application/json`
+   * **Secret**: the value of `GITHUB_SECRET` from your `.env` file.
+   * **Event**: choose **Just the push event**.
+
+When you push to the `main` branch the webhook container will pull the latest
+code, rebuild the images and restart the services.
+
+### Strapi
+
+In the Strapi admin panel open **Settings → Webhooks** and create a new webhook:
+
+* **URL**: `http://<your-domain>/webhook/strapi`
+* **Header**: `Authorization: Bearer <STRAPI_WEBHOOK_SECRET from .env>`
+* **Events**: choose the entry create/update/delete events you want.
+
+Whenever content changes, the frontend container is restarted which rebuilds the
+static site using the new data.
+
+## 5. Useful Commands
+
+- `docker compose ps` – check running containers.
+- `docker compose logs -f <service>` – view logs.
+- `docker compose down` – stop all containers.
+- `docker compose pull && docker compose build && docker compose up -d` – manual
+  update without the webhook server.
+
+## 6. Notes on Building Packages
+
+Both Strapi and Eleventy depend on native modules (`sharp` and `canvas`). The
+Dockerfiles install the build tools and libraries required for these modules so
+they compile correctly on Apple Silicon. If you ever run `npm install` outside
+Docker on your Mac, run `./portfolio-frontend/fix-canvas-module.sh` to rebuild
+`canvas` for your architecture.
+
+---
+With this setup you can manage content in Strapi and push code to GitHub.
+Everything is rebuilt automatically using Docker.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  strapi:
+    build: ./portfolio-cms
+    env_file: .env
+    environment:
+      - NODE_ENV=production
+      - DATABASE_CLIENT=sqlite
+      - DATABASE_FILENAME=/data/strapi.db
+      - STRAPI_TELEMETRY_DISABLED=true
+    volumes:
+      - strapi-data:/data
+      - strapi-uploads:/app/public/uploads
+    restart: unless-stopped
+
+  eleventy:
+    build: ./portfolio-frontend
+    environment:
+      - STRAPI_URL=http://strapi:1337
+    depends_on:
+      - strapi
+    volumes:
+      - strapi-uploads:/app/public/uploads:ro
+    ports:
+      - "80:80"
+    restart: unless-stopped
+
+  webhook:
+    build: ./webhook
+    env_file: .env
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+
+volumes:
+  strapi-data:
+  strapi-uploads:

--- a/portfolio-cms/Dockerfile
+++ b/portfolio-cms/Dockerfile
@@ -1,15 +1,15 @@
 FROM node:18-alpine
 
-# Install dependencies for building native modules
-RUN apk add --no-cache python3 make g++
+# Install dependencies for building native modules and image processing
+RUN apk add --no-cache python3 make g++ vips-dev
 
 WORKDIR /app
 
 # Copy package files first for better caching
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Install dependencies (including dev for build)
+RUN npm ci
 
 # Copy application files
 COPY . .
@@ -17,13 +17,17 @@ COPY . .
 # Build Strapi admin
 RUN npm run build
 
+# Remove dev dependencies to keep image small
+RUN npm prune --production && rm -rf /root/.npm
+
 # Create uploads directory
 RUN mkdir -p public/uploads
 
 # Expose Strapi port
 EXPOSE 1337
 
-# Use node user for security
-USER node
+# Run as root so the container can write to mounted volumes
+# (the mounted volumes are owned by root by default)
+USER root
 
 CMD ["npm", "start"]

--- a/portfolio-frontend/Dockerfile
+++ b/portfolio-frontend/Dockerfile
@@ -1,41 +1,28 @@
-# Use a standard Debian-based image which has great ARM64 support
-FROM node:18-bullseye as builder
+FROM node:18-bullseye as base
 
-# Install a comprehensive list of dependencies needed to compile `canvas` for ARM64
+# Install build requirements for canvas
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libcairo2-dev \
     libjpeg62-turbo-dev \
     libpango1.0-dev \
     libgif-dev \
-    librsvg2-dev
+    librsvg2-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
-
-# Delete any existing node_modules that might have been copied (safety measure)
-RUN rm -rf node_modules
-
-# Install dependencies (will now compile canvas correctly for linux/arm64)
 RUN npm ci
-
-# Copy source files (excluding node_modules thanks to .dockerignore)
 COPY . .
 
-# Build static site
-RUN npm run build
-
-# --- Production Stage (still nice and small) ---
-FROM nginx:alpine
-
-# Copy built files from the builder stage
-COPY --from=builder /app/_site /usr/share/nginx/html
-
-# Copy our custom nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-
+FROM node:18-alpine
+RUN apk add --no-cache nginx
+WORKDIR /app
+COPY --from=base /app /app
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY nginx.conf /etc/nginx/http.d/default.conf
+RUN chmod +x /docker-entrypoint.sh
+ENV STRAPI_URL=http://strapi:1337
 EXPOSE 80
-
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/docker-entrypoint.sh"]

--- a/portfolio-frontend/docker-entrypoint.sh
+++ b/portfolio-frontend/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# wait for Strapi to be reachable
+until curl -s "$STRAPI_URL" >/dev/null 2>&1; do
+  echo "Waiting for Strapi at $STRAPI_URL..."
+  sleep 3
+done
+
+npm run build
+cp -r _site/* /usr/share/nginx/html/
+exec nginx -g 'daemon off;'

--- a/portfolio-frontend/nginx.conf
+++ b/portfolio-frontend/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name _;
     root /usr/share/nginx/html;
     index index.html;
 
@@ -8,7 +8,22 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Enable gzip compression
+    location /api/ {
+        proxy_pass http://strapi:1337/api/;
+    }
+
+    location /admin/ {
+        proxy_pass http://strapi:1337/;
+    }
+
+    location /uploads/ {
+        proxy_pass http://strapi:1337/uploads/;
+    }
+
+    location /webhook/ {
+        proxy_pass http://webhook:3000/;
+    }
+
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+echo "Pulling latest code..."
+git pull origin main
+
+echo "Building containers..."
+docker compose build --pull
+
+echo "Restarting services..."
+docker compose up -d

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+echo "Rebuilding static site..."
+docker compose restart eleventy

--- a/webhook/Dockerfile
+++ b/webhook/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+
+RUN apk add --no-cache docker-cli
+
+# Run as root so the webhook handler can access the Docker socket
+USER root
+
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/webhook/index.js
+++ b/webhook/index.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const crypto = require('crypto');
+const { exec } = require('child_process');
+const path = require('path');
+
+const app = express();
+app.use(express.json());
+
+const githubSecret = process.env.GITHUB_SECRET || '';
+const strapiSecret = process.env.STRAPI_WEBHOOK_SECRET || '';
+const repoPath = '/workspace';
+
+function runScript(script) {
+  return new Promise((resolve, reject) => {
+    exec(script, { cwd: repoPath }, (err, stdout, stderr) => {
+      if (err) return reject(err);
+      console.log(stdout);
+      console.error(stderr);
+      resolve();
+    });
+  });
+}
+
+function verifyGitHub(req) {
+  const signature = req.headers['x-hub-signature-256'];
+  const digest = 'sha256=' + crypto.createHmac('sha256', githubSecret).update(JSON.stringify(req.body)).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(signature || ''), Buffer.from(digest));
+}
+
+app.post('/github', async (req, res) => {
+  if (!verifyGitHub(req)) {
+    return res.status(401).end();
+  }
+  if (req.body.ref === 'refs/heads/main') {
+    try {
+      await runScript('scripts/deploy.sh');
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  res.json({ ok: true });
+});
+
+app.post('/strapi', async (req, res) => {
+  const token = req.headers['authorization']?.replace('Bearer ', '') || '';
+  if (token !== strapiSecret) {
+    return res.status(401).end();
+  }
+  try {
+    await runScript('scripts/rebuild.sh');
+  } catch (e) {
+    console.error(e);
+  }
+  res.json({ ok: true });
+});
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(3000, () => console.log('Webhook server running on 3000'));

--- a/webhook/package.json
+++ b/webhook/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "webhook-handler",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add docker-compose with Strapi, Eleventy and webhook services
- update Strapi Dockerfile for sharp dependencies
- refactor frontend Dockerfile to build on container start
- configure nginx to proxy to Strapi and webhook handler
- add webhook handler container and deployment scripts
- provide deployment instructions in `DEPLOYMENT_GUIDE.md`
- add `.env.example` and `.gitignore`
- adjust container permissions for Strapi and webhook

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ba088a5008331a64373ec4bce0321